### PR TITLE
Add dataset generation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,43 @@ go build -ldflags "-X suitop/internal/version.GitCommit=$(git rev-parse HEAD) -X
 ./suitop --generate-dataset
 ```
 
+## Dataset Mode
+
+When `--generate-dataset` (or `GENERATE_DATASET=true`) is enabled the tool runs
+in plain mode and keeps validator signatures in memory until you press `q` then
+`Enter`.
+
+Every epoch is flushed to a JSON file inside `DATASET_FOLDER` (defaults to
+`./data`).  Files are named `epoch_<epoch>_<start>-<end>.json` where `<start>` and
+`<end>` are the first and last checkpoint sequence numbers recorded.
+
+The JSON structure contains an array of validators with a bitmap of all
+checkpoints in order:
+
+```json
+{
+  "epoch": 42,
+  "start_checkpoint": 10000,
+  "end_checkpoint": 10100,
+  "validators": [
+    {
+      "name": "Validator A",
+      "address": "0x...",
+      "signed": 90,
+      "total": 101,
+      "bitmap": "...base64 bytes..."
+    }
+  ]
+}
+```
+
+The `bitmap` field is base64‑encoded.  When decoded, each bit corresponds to a
+checkpoint starting from the least significant bit of the first byte.  A set bit
+(value `1`) means the validator signed that checkpoint.
+
+Progress is printed every 10 checkpoints with a reminder that you can press `q`
+to finish recording.
+
 ## Usage
 
 - Press `q` or `Ctrl+C` to quit the application

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The application can be configured using environment variables:
 - `NO_ALT_SCREEN`: Set to `true` to run inside current terminal buffer (default: `false`).
 - `LOG_TO_FILE`: Set to `true` to write logs to a file (default: `false`).
 - `LOG_FILE_PATH`: Path to log file (default: `~/.suitop/logs/suitop.log`).
+- `GENERATE_DATASET`: Enable dataset generation mode (default: `false`).
+- `DATASET_FOLDER`: Folder to store dataset files (default: `./data`).
 
 ## Command-line Flags
 
@@ -36,6 +38,7 @@ These flags override the corresponding environment variables:
 - `--no-alt-screen`: Run inside current terminal buffer (useful for tmux logs)
 - `--log-to-file`: Write logs to a file
 - `--log-file [path]`: Path to log file
+- `--generate-dataset`: Enable dataset generation mode
 
 ## Building
 
@@ -65,6 +68,9 @@ go build -ldflags "-X suitop/internal/version.GitCommit=$(git rev-parse HEAD) -X
 
 # Run with logging to a file
 ./suitop --log-to-file --log-file /path/to/logfile.log
+
+# Generate dataset in plain mode
+./suitop --generate-dataset
 ```
 
 ## Usage

--- a/internal/checkpoint/dataset.go
+++ b/internal/checkpoint/dataset.go
@@ -1,0 +1,121 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	val "suitop/internal/validator"
+)
+
+type validatorEntry struct {
+	Name    string `json:"name"`
+	Address string `json:"address"`
+	Signed  uint64 `json:"signed"`
+	Total   uint64 `json:"total"`
+	Bitmap  []byte `json:"bitmap"`
+}
+
+type epochData struct {
+	Epoch           uint64                     `json:"epoch"`
+	StartCheckpoint uint64                     `json:"start_checkpoint"`
+	EndCheckpoint   uint64                     `json:"end_checkpoint"`
+	Validators      map[string]*validatorEntry `json:"-"`
+	Order           []string                   `json:"-"`
+}
+
+// DatasetManager manages dataset collection for a single epoch.
+type DatasetManager struct {
+	folder string
+	data   *epochData
+}
+
+func NewDatasetManager(folder string) (*DatasetManager, error) {
+	if folder == "" {
+		folder = "./data"
+	}
+	if err := os.MkdirAll(folder, 0755); err != nil {
+		return nil, err
+	}
+	return &DatasetManager{folder: folder}, nil
+}
+
+func (dm *DatasetManager) startEpoch(epoch uint64, committee []val.ValidatorInfo, startSeq uint64) {
+	dm.data = &epochData{
+		Epoch:           epoch,
+		StartCheckpoint: startSeq,
+		EndCheckpoint:   startSeq,
+		Validators:      make(map[string]*validatorEntry),
+		Order:           make([]string, 0, len(committee)),
+	}
+	for _, v := range committee {
+		dm.data.Validators[v.SuiAddress] = &validatorEntry{Name: v.Name, Address: v.SuiAddress}
+		dm.data.Order = append(dm.data.Order, v.SuiAddress)
+	}
+}
+
+func (dm *DatasetManager) appendBit(v *validatorEntry, signed bool) {
+	byteIndex := int(v.Total / 8)
+	if byteIndex >= len(v.Bitmap) {
+		v.Bitmap = append(v.Bitmap, 0)
+	}
+	if signed {
+		v.Bitmap[byteIndex] |= 1 << (v.Total % 8)
+		v.Signed++
+	}
+	v.Total++
+}
+
+// RecordCheckpoint records signatures for a checkpoint.
+func (dm *DatasetManager) RecordCheckpoint(epoch uint64, seq uint64, bitmap []uint32, committee []val.ValidatorInfo) {
+	if dm.data == nil {
+		dm.startEpoch(epoch, committee, seq)
+	}
+	if dm.data.Epoch != epoch {
+		dm.finishEpoch()
+		dm.startEpoch(epoch, committee, seq)
+	}
+	dm.data.EndCheckpoint = seq
+	for _, v := range committee {
+		entry, ok := dm.data.Validators[v.SuiAddress]
+		if !ok {
+			entry = &validatorEntry{Name: v.Name, Address: v.SuiAddress}
+			dm.data.Validators[v.SuiAddress] = entry
+			dm.data.Order = append(dm.data.Order, v.SuiAddress)
+		}
+		signed := IsValidatorSigned(bitmap, v.BitmapIndex)
+		dm.appendBit(entry, signed)
+	}
+}
+
+func (dm *DatasetManager) finishEpoch() {
+	if dm.data == nil {
+		return
+	}
+	fileName := fmt.Sprintf("epoch_%d_%d-%d.json", dm.data.Epoch, dm.data.StartCheckpoint, dm.data.EndCheckpoint)
+	path := fmt.Sprintf("%s/%s", dm.folder, fileName)
+
+	out := struct {
+		Epoch           uint64           `json:"epoch"`
+		StartCheckpoint uint64           `json:"start_checkpoint"`
+		EndCheckpoint   uint64           `json:"end_checkpoint"`
+		Validators      []validatorEntry `json:"validators"`
+	}{
+		Epoch:           dm.data.Epoch,
+		StartCheckpoint: dm.data.StartCheckpoint,
+		EndCheckpoint:   dm.data.EndCheckpoint,
+	}
+	for _, addr := range dm.data.Order {
+		out.Validators = append(out.Validators, *dm.data.Validators[addr])
+	}
+
+	f, err := os.Create(path)
+	if err == nil {
+		json.NewEncoder(f).Encode(out)
+		f.Close()
+	}
+	dm.data = nil
+}
+
+func (dm *DatasetManager) Close() {
+	dm.finishEpoch()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	RPCClientConfig      RPCClientConfig      // For RPC client settings passed to validator.Loader
 	UIConfig             UIConfig             // For UI related settings
 	LogConfig            LogConfig            // For logging configuration
+	DatasetConfig        DatasetConfig        // For dataset generation
 }
 
 // GRPCConfig holds gRPC specific settings.
@@ -57,6 +58,11 @@ type LogConfig struct {
 	FilePath  string // Path to log file
 	WithTime  bool   // Include timestamps in logs
 	WithLevel bool   // Include log levels in messages
+}
+
+type DatasetConfig struct {
+	Generate bool
+	Folder   string
 }
 
 // Load populates Config from environment variables or defaults.
@@ -121,6 +127,16 @@ func Load() *Config {
 		}
 	}
 
+	generateDatasetStr := os.Getenv("GENERATE_DATASET")
+	generateDataset := false
+	if generateDatasetStr == "true" {
+		generateDataset = true
+	}
+	datasetFolder := os.Getenv("DATASET_FOLDER")
+	if datasetFolder == "" {
+		datasetFolder = "./data"
+	}
+
 	return &Config{
 		SuiNode:           suiNode,
 		JSONRPCURL:        jsonRPCURL,
@@ -147,6 +163,10 @@ func Load() *Config {
 			FilePath:  logFilePath,
 			WithTime:  true,
 			WithLevel: true,
+		},
+		DatasetConfig: DatasetConfig{
+			Generate: generateDataset,
+			Folder:   datasetFolder,
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- add new dataset mode flag and config
- implement DatasetManager to build per-epoch JSON files
- wire dataset logic into processor and main program
- document dataset mode usage and env vars

## Testing
- `go build ./cmd/suitop`

------
https://chatgpt.com/codex/tasks/task_e_68498f630f2c8327bf7851f4b9f17bed