### PR TITLE
Fix epoch detection from signature

### DIFF
--- a/internal/checkpoint/processor.go
+++ b/internal/checkpoint/processor.go
@@ -68,8 +68,10 @@ func (p *Processor) Run(ctx context.Context, initialEpoch uint64, initialCommitt
 
 			p.statsManager.IncrementTotalCheckpointsWithSig()
 
-			// Assuming Summary has an Epoch field
-			checkpointEpochVal := receivedCheckpoint.GetSummary().GetEpoch()
+			// Epoch value is stored inside the validator aggregated signature
+			// which is guaranteed to be present in the subscription
+			// because we request the full signature message.
+			checkpointEpochVal := receivedCheckpoint.GetSignature().GetEpoch()
 
 			// Epoch change detection and committee reload
 			if checkpointEpochVal > p.currentEpoch {

--- a/internal/grpc/subscriber.go
+++ b/internal/grpc/subscriber.go
@@ -43,11 +43,10 @@ func SubscribeToCheckpoints(
 		log.Println("Attempting to subscribe to checkpoints...")
 		stream, err := subClient.SubscribeCheckpoints(ctx, &subPb.SubscribeCheckpointsRequest{
 			ReadMask: &fieldmaskpb.FieldMask{
-				// Ensure these paths are correct for subPb.CheckpointData fields you need.
-				// Original main.go used: "signature", "sequence_number", "epoch"
-				// Assuming CheckpointData has these or equivalent.
-				// If CheckpointData contains a nested Checkpoint struct with these, adjust paths e.g. "checkpoint.signature"
-				Paths: []string{"signature", "sequence_number", "epoch"},
+				// We only require the aggregated signature (which includes
+				// the epoch information) and the sequence number of the
+				// checkpoint. Requesting fewer fields reduces payload size.
+				Paths: []string{"signature", "sequence_number"},
 			},
 		})
 


### PR DESCRIPTION
## Summary
- handle epoch transitions using `signature.epoch`
- trim subscriber read mask to signature and sequence number only

## Testing
- `go test ./...` *(fails: pocs/subscribe_checkpoints build error)*

------
https://chatgpt.com/codex/tasks/task_e_684c30222448832798f55c299f8430d5